### PR TITLE
feat: add deepseekv4.reasoningEffort setting (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [released]
 
+## [0.3.2] - 2026-04-29
+
+### Added
+
+- New setting `deepseekv4.reasoningEffort` (`"high"` | `"max"`, default `"max"`)
+  to control reasoning depth on `(thinking)` model variants. Switch to `high`
+  for faster, lighter responses on simple chat without changing models. Has
+  no effect on non-thinking variants. Reads at request time, so changes apply
+  to the next message without reloading.
+
+### Changed
+
+- `MODEL_VARIANTS` no longer hardcodes `effort: "max"` on thinking variants;
+  the value comes from the new user setting at request time. Variant tooltips
+  drop the "at max effort" suffix to match.
+- `DeepSeekModelVariant` type drops the `effort?: "high" | "max"` field. This
+  is an internal type; no public API is affected.
+
 ## [0.3.1] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   for faster, lighter responses on simple chat without changing models. Has
   no effect on non-thinking variants. Reads at request time, so changes apply
   to the next message without reloading.
+- Status-bar tooltip now shows the current `reasoning_effort` value with a
+  click-through link that opens the setting directly. Improves discoverability
+  for the new option without intrusive notifications.
+- Walkthrough adds a third step (**Tune reasoning effort (optional)**) that
+  introduces the new setting to first-time users with a one-click link to the
+  setting and a brief explanation of `high` vs `max`.
+- Per-request `[req] reasoning_effort=<value> (variant=<id>)` log line in the
+  output channel, so users and developers can confirm at a glance which
+  effort each request is sending.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ This extension is a native VS Code Language Model Provider — it intercepts eac
 | `Show DeepSeek V4 Reasoning Cache Stats` | Diagnostics for the reasoning cache |
 | `Clear DeepSeek V4 Session Counter` | Reset the session spend display |
 
+## Settings
+
+| Setting | Values | Default | Description |
+| ------ | ------ | ------ | ------ |
+| `deepseekv4.reasoningEffort` | `high` \| `max` | `max` | Reasoning depth for `(thinking)` model variants. `high` is faster with shorter reasoning chains; `max` is the deepest setting. No effect on non-thinking variants. Picked up at request time. |
+
 ## License
 
 MIT. See [LICENSE](./LICENSE). Forked from [huggingface-vscode-chat](https://github.com/huggingface/huggingface-vscode-chat); the protocol layer was rewritten for DeepSeek V4.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "deepseek-v4-vscode-chat",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "deepseek-v4-vscode-chat",
-			"version": "0.3.1",
+			"version": "0.3.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@eslint/js": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,14 @@
 						"media": {
 							"markdown": "resources/walkthrough/pick-model.md"
 						}
+					},
+					{
+						"id": "tuneReasoningEffort",
+						"title": "Tune reasoning effort (optional)",
+						"description": "Switch between `high` (faster, lighter) and `max` (default, deepest) for `(thinking)` variants. Effect is global and applies to the next message.\n[Open Reasoning Effort Setting](command:workbench.action.openSettings?%22deepseekv4.reasoningEffort%22)",
+						"media": {
+							"markdown": "resources/walkthrough/tune-effort.md"
+						}
 					}
 				]
 			}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "Laurent00TT",
 	"displayName": "DeepSeek V4 Native Provider for Copilot Chat",
 	"description": "Use DeepSeek V4 (Pro / Flash) with extended thinking as a native model provider in GitHub Copilot Chat.",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"icon": "assets/icon.png",
 	"author": {
 		"name": "Laurent00TT",
@@ -70,6 +70,24 @@
 				"title": "Show DeepSeek V4 Reasoning Cache Stats"
 			}
 		],
+		"configuration": {
+			"title": "DeepSeek V4",
+			"properties": {
+				"deepseekv4.reasoningEffort": {
+					"type": "string",
+					"enum": [
+						"high",
+						"max"
+					],
+					"enumDescriptions": [
+						"Faster responses with shorter reasoning chains.",
+						"Maximum reasoning depth; slower and uses more tokens."
+					],
+					"default": "max",
+					"markdownDescription": "Reasoning effort for `(thinking)` model variants. Has no effect on non-thinking variants. See [DeepSeek docs](https://api-docs.deepseek.com/guides/thinking_mode)."
+				}
+			}
+		},
 		"walkthroughs": [
 			{
 				"id": "deepseekv4GettingStarted",

--- a/resources/walkthrough/pick-model.md
+++ b/resources/walkthrough/pick-model.md
@@ -5,7 +5,7 @@ the bottom of the chat input. You will see four DeepSeek V4 variants:
 
 | Variant | Best for |
 |---|---|
-| **DeepSeek V4 Pro (thinking)** | Complex agent tasks, deep reasoning at max effort |
+| **DeepSeek V4 Pro (thinking)** | Complex agent tasks, deep reasoning (effort tunable, see next step) |
 | **DeepSeek V4 Pro** | Strong coding without the thinking-mode latency |
 | **DeepSeek V4 Flash (thinking)** | Cheapest path to extended thinking |
 | **DeepSeek V4 Flash** | Fast everyday edits, lowest cost |

--- a/resources/walkthrough/tune-effort.md
+++ b/resources/walkthrough/tune-effort.md
@@ -1,0 +1,34 @@
+# Tune reasoning effort
+
+Thinking variants accept two effort levels via the
+`deepseekv4.reasoningEffort` setting:
+
+| Value | Behavior |
+|---|---|
+| **`max`** (default) | Deepest reasoning chain. Best for agent tasks, refactors, complex bug hunts. Uses the most reasoning tokens. |
+| **`high`** | Shorter reasoning chain, faster responses, lower cost. Good for everyday chat and simple Q&A. |
+
+The setting is read at request time, so changes take effect on the **next
+message** — no reload required.
+
+## When to switch
+
+- Stay on `max` if you mostly use Copilot Chat in agent mode with tools.
+- Switch to `high` if you find yourself in long Q&A conversations where
+  the reasoning chains feel longer than necessary.
+
+You can flip between modes any time without changing the model.
+
+## Where it shows up
+
+- Hover the **DS V4** status-bar item — it displays the current effort
+  next to a "configure" link.
+- Each request also logs `[req] reasoning_effort=...` to the
+  **DeepSeek V4** output channel (run `Show DeepSeek V4 Log`).
+
+## What it does NOT affect
+
+- Non-thinking variants (`DeepSeek V4 Pro`, `DeepSeek V4 Flash`) — the
+  setting is ignored when thinking is disabled.
+- Reasoning content already cached from prior turns — those round-trip
+  unchanged. Only the new request uses the new effort.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -30,18 +30,20 @@ const BASE_URL = "https://api.deepseek.com/v1";
  */
 // DS V4's context window is 1M (input+output total). All four variants are
 // configured to use the maximum reasonable allocation under that ceiling.
-// Thinking variants use effort=max — Think Max requires ≥384K of reasoning
-// budget, so we give them 256K output (which subsumes the reasoning chain).
+// Thinking variants budget 256K output to comfortably subsume the reasoning
+// chain (Think Max needs ≥384K of reasoning budget when effort=max).
+//
+// `reasoning_effort` is read from the `deepseekv4.reasoningEffort` user
+// setting at request time, not stored on the variant.
 //
 // Listed strongest→cheapest; VS Code uses the first entry as the default.
 const MODEL_VARIANTS: DeepSeekModelVariant[] = [
 	{
 		id: "deepseek-v4-pro::thinking",
 		displayName: "DeepSeek V4 Pro (thinking)",
-		tooltip: "DeepSeek V4 Pro — strongest, extended thinking at max effort",
+		tooltip: "DeepSeek V4 Pro — strongest, extended thinking",
 		apiModel: "deepseek-v4-pro",
 		thinking: true,
-		effort: "max",
 		maxInputTokens: 720896,   // 704K
 		maxOutputTokens: 262144,  // 256K (subsumes the 384K reasoning chain budget)
 	},
@@ -57,10 +59,9 @@ const MODEL_VARIANTS: DeepSeekModelVariant[] = [
 	{
 		id: "deepseek-v4-flash::thinking",
 		displayName: "DeepSeek V4 Flash (thinking)",
-		tooltip: "DeepSeek V4 Flash — cheapest with extended thinking at max effort",
+		tooltip: "DeepSeek V4 Flash — cheapest with extended thinking",
 		apiModel: "deepseek-v4-flash",
 		thinking: true,
-		effort: "max",
 		maxInputTokens: 720896,   // 704K
 		maxOutputTokens: 262144,  // 256K
 	},
@@ -947,9 +948,15 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
             };
 
 			if (variant.thinking) {
-				if (variant.effort) {
-					(requestBody as Record<string, unknown>).reasoning_effort = variant.effort;
-				}
+				const raw = vscode.workspace
+					.getConfiguration("deepseekv4")
+					.get<string>("reasoningEffort", "max");
+				// Defensive: the package.json schema constrains the settings UI to
+				// "high" | "max", but a hand-edited settings.json could contain
+				// anything. Coerce unknown values to "max" rather than passing
+				// arbitrary strings to the API.
+				const effort: "high" | "max" = raw === "high" ? "high" : "max";
+				(requestBody as Record<string, unknown>).reasoning_effort = effort;
 				// Per DeepSeek docs: temperature/top_p/penalty params are ignored
 				// in thinking mode. We omit them to keep the request body honest.
 			} else {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -957,6 +957,7 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
 				// arbitrary strings to the API.
 				const effort: "high" | "max" = raw === "high" ? "high" : "max";
 				(requestBody as Record<string, unknown>).reasoning_effort = effort;
+				this.outputChannel.appendLine(`[req] reasoning_effort=${effort} (variant=${variant.id})`);
 				// Per DeepSeek docs: temperature/top_p/penalty params are ignored
 				// in thinking mode. We omit them to keep the request body honest.
 			} else {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -533,6 +533,16 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
 		}
 
 		md.appendMarkdown("---\n\n");
+
+		// Reasoning effort row: shows the current setting value plus a click-
+		// through to the specific setting. Helps discoverability — users who
+		// hover the status bar to check cost will also notice this control.
+		const currentEffort = vscode.workspace
+			.getConfiguration("deepseekv4")
+			.get<string>("reasoningEffort", "max");
+		md.appendMarkdown(
+			`**Reasoning effort** &nbsp; \`${currentEffort}\` &nbsp; [$(gear) configure](command:workbench.action.openSettings?%22deepseekv4.reasoningEffort%22)\n\n`,
+		);
 		md.appendMarkdown("[View full log](command:deepseekv4.showLog)");
 
 		return md;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,8 +60,12 @@ export interface ToolCallBuffer {
 /**
  * DeepSeek model variant published to the VS Code model picker.
  * `apiModel` is what we send in the OpenAI-compatible request body;
- * `thinking` controls whether to enable extended thinking mode;
- * `effort` is forwarded as `reasoning_effort` ("high" or "max") when thinking is on.
+ * `thinking` controls whether to enable extended thinking mode.
+ *
+ * `reasoning_effort` is no longer a per-variant constant — it is read at
+ * request time from the user setting `deepseekv4.reasoningEffort` (values
+ * `"high"` | `"max"`, default `"max"`). The setting only takes effect for
+ * variants where `thinking === true`.
  */
 export interface DeepSeekModelVariant {
 	id: string;
@@ -69,7 +73,6 @@ export interface DeepSeekModelVariant {
 	tooltip: string;
 	apiModel: "deepseek-v4-pro" | "deepseek-v4-flash";
 	thinking: boolean;
-	effort?: "high" | "max";
 	maxInputTokens: number;
 	maxOutputTokens: number;
 }


### PR DESCRIPTION
## Summary

- Adds VS Code setting `deepseekv4.reasoningEffort` (`high` | `max`, default `max`) to replace the hardcoded `effort: "max"` on thinking variants.
- Setting is read at request time, so users can flip between messages without reloading.
- Discoverability via status-bar tooltip (shows current value + click-through to setting) and a new walkthrough step.
- Per-request `[req] reasoning_effort=...` log line in the output channel for transparency.

Default behavior is unchanged (still `max`). Backwards-compatible patch.

This addresses the same problem as #1 with a different design — VS Code Settings via standard `contributes.configuration` rather than a picker dropdown via the proposed `configurationSchema` API. Tradeoff: less convenient (settings vs picker), but no proposed-API dependency and survives upstream Copilot Chat API changes. #1 will be reviewed and closed separately with thanks.

## Changes

- `package.json` — `contributes.configuration` for the new setting; walkthrough gains a third step `tuneReasoningEffort`
- `src/types.ts` — `DeepSeekModelVariant` drops the optional `effort` field
- `src/provider.ts` — `MODEL_VARIANTS` drops hardcoded `effort: "max"` and "at max effort" tooltip suffixes; request construction reads from the setting and logs `[req] reasoning_effort=...`; status-bar tooltip gains an effort row with a configure link
- `resources/walkthrough/tune-effort.md` — new walkthrough markdown with high vs max guidance
- `resources/walkthrough/pick-model.md` — minor tweak to align language
- `CHANGELOG.md` — 0.3.2 section
- `README.md` — Settings table

## Test plan

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm run package` produces a clean .vsix (15 files, ~70 KB)
- [x] Settings UI shows the Reasoning Effort dropdown with `high` | `max` and the right description
- [x] Status-bar tooltip shows the current effort with a configure click-through that opens the setting directly
- [x] Walkthrough has the new "Tune reasoning effort (optional)" step that links to the setting
- [x] Switching effort takes effect on the next message; verified via the `[req]` log line and noticeably different reasoning chain length between `high` and `max`
- [x] Non-thinking variants are unaffected (no `reasoning_effort` field sent)
- [x] Default `max` reproduces 0.3.1 behavior

## Backwards compatibility

Default `max` matches prior 0.3.1 behavior. No request shape changes for users who don't touch the new setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)