### PR TITLE
feat(status-bar): show account balance inline

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -458,7 +458,10 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
 	}
 
 	private refreshStatusBar(): void {
-		this.statusBar.text = "$(sparkle) DS V4";
+		const balanceStr = this._balance
+			? ` ${currencySymbol(this._balance.currency)}${this._balance.totalBalance.toFixed(2)}`
+			: "";
+		this.statusBar.text = `$(sparkle) DS V4${balanceStr}`;
 		this.statusBar.tooltip = this.buildTooltip();
 		this.statusBar.show();
 	}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -455,11 +455,16 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
 		);
 
 		this.refreshStatusBar();
+
+		// Fire-and-forget initial fetch so the status bar shows balance after
+		// VS Code reload without requiring a manual hover-refresh first.
+		// Silent: errors swallowed — no-op if API key isn't configured yet.
+		void this.refreshBalance(true);
 	}
 
 	private refreshStatusBar(): void {
 		const balanceStr = this._balance
-			? ` ${currencySymbol(this._balance.currency)}${this._balance.totalBalance.toFixed(2)}`
+			? `  ${currencySymbol(this._balance.currency)}${this._balance.totalBalance.toFixed(2)}`
 			: "";
 		this.statusBar.text = `$(sparkle) DS V4${balanceStr}`;
 		this.statusBar.tooltip = this.buildTooltip();


### PR DESCRIPTION
## What does this PR do?

Closes #5

Render the cached account balance inline in the status bar text, so users can see their balance without hovering:

```
$(sparkle) DS V4               (no balance fetched yet)
$(sparkle) DS V4  ¥13.33       (after a balance has been fetched)
```

A silent background fetch is also kicked off in the constructor so the balance shows up automatically after a VS Code reload — no manual hover-refresh needed.

The hover tooltip is intentionally unchanged. It remains the source of truth for the fetchedAt timestamp, the granted/topped-up split, and any currency-mismatch warnings.

**No persistence**: the balance is not written to globalState. On reload, the constructor's background fetch repopulates it. This avoids the failure mode of displaying stale numbers as if they were current.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (existing behavior changes)
- [ ] Docs / refactor / chore

## Testing

- [x] `npm run compile` passes
- [x] `npm run lint` passes on `src/provider.ts` (pre-existing warnings in `docs/experiments/*.mjs` are out of scope)
- [x] Manually tested via vsix install + Reload Window — verified the balance appears automatically a couple seconds after reload, and that the unfetched state still shows just `DS V4` with no trailing artifacts

## Notes for reviewers

This is an alternative to #6 with a much smaller surface area (~10 lines in one method).

#6 also adds session cost display, persistence to globalState, and a custom money formatter. Those each have edge cases I'd rather avoid pulling into the codebase right now: doubled `|` separators when balance is unfetched but cost is set, stale balance shown after restart, `< 0.01` rounding to "0", etc.

This PR scopes to exactly what #5 asks for ("show balance in the status bar without hovering") and keeps the tooltip as the source of truth for everything else. If session cost / persistence / formatting come up again later, they can each land as their own focused change.