### PR TITLE
fix: prevent 400 error on reasoning_content cache miss in thinking mode

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1415,6 +1415,7 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
                 hits++;
             } else {
                 misses++;
+                msg.reasoning_content = "";  // fallback: prevent guaranteed 400 when cache misses
                 const tcSummary = (msg.tool_calls ?? []).map((tc) => `${tc.function.name}:${tc.id}`);
                 this.log("cache.MISS", {
                     fp,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1394,10 +1394,11 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
      * confirm: DeepSeek's actual rule for thinking-mode requests is:
      *   - `tools` not advertised → only tc-assistant turns NEED reasoning
      *   - `tools` advertised     → ALL prior assistant turns NEED reasoning
-     * Mutates messages in place.
-     * On cache miss, sets reasoning_content="" as fallback to prevent a
-     * guaranteed 400 from the API. The conversation may be slightly degraded
-     * (the model loses one turn's reasoning context) but can continue.
+     * Mutates messages in place. On cache miss, sets reasoning_content="" as
+     * fallback to prevent a guaranteed 400 from the API. The conversation may
+     * be slightly degraded (the model loses one turn's reasoning context) but
+     * can continue. Direct extraction from LanguageModelThinkingPart in
+     * convertMessages() handles most cases; this fallback is the last line.
      */
     private attachReasoningToHistory(messages: OpenAIChatMessage[]): void {
         let hits = 0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,11 +142,21 @@ function sanitizeSchema(input: unknown, propName?: string): Record<string, unkno
  */
 export function convertMessages(messages: readonly vscode.LanguageModelChatRequestMessage[]): OpenAIChatMessage[] {
 	const out: OpenAIChatMessage[] = [];
+
+	// Try to resolve LanguageModelThinkingPart constructor — may not exist in
+	// older VS Code builds. When available, we can extract reasoning_content
+	// directly from the host message history instead of relying solely on
+	// the ReasoningCache.
+	const ThinkingPartCtor = (vscode as unknown as Record<string, unknown>)["LanguageModelThinkingPart"] as
+		| (new (...args: unknown[]) => unknown)
+		| undefined;
+
 	for (const m of messages) {
 		const role = mapRole(m);
 		const textParts: string[] = [];
 		const toolCalls: OpenAIToolCall[] = [];
 		const toolResults: { callId: string; content: string }[] = [];
+		let reasoningContent: string | undefined;
 
 		for (const part of m.content ?? []) {
 			if (part instanceof vscode.LanguageModelTextPart) {
@@ -164,12 +174,29 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
 				const callId = (part as { callId?: string }).callId ?? "";
 				const content = collectToolResultText(part as { content?: ReadonlyArray<unknown> });
 				toolResults.push({ callId, content });
+			} else if (ThinkingPartCtor && part instanceof ThinkingPartCtor) {
+				// VS Code passes thinking content back in chat history.
+				// Accumulate it so we can round-trip it as reasoning_content
+				// on the assistant message. This is the most reliable source
+				// because it doesn't depend on fingerprint matching.
+				const val = (part as { value?: unknown }).value;
+				if (typeof val === "string" && val.length > 0) {
+					if (!reasoningContent) {
+						reasoningContent = "";
+					}
+					reasoningContent += val;
+				}
 			}
 		}
 
 		let emittedAssistantToolCall = false;
 		if (toolCalls.length > 0) {
-			out.push({ role: "assistant", content: textParts.join("") || undefined, tool_calls: toolCalls });
+			out.push({
+				role: "assistant",
+				content: textParts.join("") || undefined,
+				tool_calls: toolCalls,
+				reasoning_content: reasoningContent,
+			});
 			emittedAssistantToolCall = true;
 		}
 
@@ -179,7 +206,11 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
 
 		const text = textParts.join("");
 		if (text && (role === "system" || role === "user" || (role === "assistant" && !emittedAssistantToolCall))) {
-			out.push({ role, content: text });
+			out.push({ role, content: text, reasoning_content: reasoningContent });
+		} else if (!text && !emittedAssistantToolCall && reasoningContent && role === "assistant") {
+			// Reasoning-only assistant turn: no visible text and no tool calls,
+			// but we have thinking content that must be round-tripped.
+			out.push({ role: "assistant", reasoning_content: reasoningContent });
 		}
 	}
 	return out;


### PR DESCRIPTION
## Problem

In thinking mode, when `attachReasoningToHistory` encounters a cache MISS for a prior assistant turn, the `reasoning_content` field is omitted from the API request, causing DeepSeek to return HTTP 400:

> The reasoning_content in the thinking mode must be passed back to the API.

This deadlocks the conversation permanently — every retry hits the same error. See issue #X for detailed logs.

## Root Cause

Two gaps:

1. **convertMessages()** never extracts `reasoning_content` from VS Code's `LanguageModelThinkingPart` in chat history. The `ReasoningCache` (fingerprint-based lookup) is the *only* source, and it can miss due to fingerprint mismatch, LRU eviction, or empty reasoning.

2. **attachReasoningToHistory()** on cache MISS logs the event but doesn't set `reasoning_content`, leaving the field absent → guaranteed 400.

## Fix (two complementary layers)

### Layer 1 — Direct extraction (utils.ts)
`convertMessages()` now detects `LanguageModelThinkingPart` in VS Code message parts and extracts the reasoning content verbatim. This is more reliable than fingerprint-based cache lookup because it recovers the actual reasoning text directly from the host.

### Layer 2 — Defensive fallback (provider.ts)
`attachReasoningToHistory()` now sets `reasoning_content = ""` on cache MISS instead of omitting the field. This prevents a guaranteed 400 when layer 1 also fails (older VS Code without thinking parts, edge cases). The conversation continues; the model loses one turn's reasoning context at worst.

## Files changed
- `src/utils.ts` — extract reasoning from LanguageModelThinkingPart
- `src/provider.ts` — fallback reasoning_content="" on cache MISS

## Testing

- [x] TypeScript compiles cleanly (`tsc -p ./`)
- [x] Existing integration tests pass
- [x] Manual: long multi-turn conversation with thinking mode no longer deadlocks on 400