### PR TITLE
fix(tools): enforce the 128-tool cap on the advertised set, not the host list

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,22 @@ Unusable names (empty after sanitization) skip just that tool with a
 split or hash breaks fingerprint continuity for conversations that span
 extension versions, so it must be a deliberate, versioned decision.
 
+Because tools can be skipped, DeepSeek's 128-tools-per-request cap is
+enforced against the **advertised** set, not `options.tools` — a host list
+slightly over 128 whose skips bring the broadcast set back under the cap is
+a legal request. The payload assembly itself (schema sanitization, skip
+logic, tool_choice) lives in the vscode-free `src/tool_payload.ts` — the
+third extraction after `tool_names.ts` and `tool_choice.ts`, with
+`convertTools` reduced to a thin enum→boolean adapter — so
+`test/unit_tool_limit.mjs` executes the real skip-then-count path (130 host
+tools, 5 unusable → 125 advertised → guard passes). The guard
+(`src/tool_limit.ts`) takes the advertised `OpenAIFunctionToolDef[]` rather
+than a count: VS Code's host tool shape is structurally incompatible, so
+feeding `options.tools` — or any hand-computed number — fails to compile. A
+deliberately minimal, best-effort text pin over comment-stripped
+`out/provider.js` covers the two properties types can't enforce: the guard
+call exists, and no inline host-list count check has crept back.
+
 ## Finish reasons
 
 DeepSeek can return five `finish_reason` values, including special ones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The 128-tools-per-request cap now counts the tools actually sent to the API, not the raw host list.** The pre-request guard in `provideLanguageModelChatResponse` counted `options.tools`, but since the issue #20 wire-aliasing fix tool assembly may skip unusable or colliding tools — so a host list slightly over 128 whose broadcast set is back under the cap was rejected for a violation that never reached the wire. The guard (`assertAdvertisedToolLimit` in `src/tool_limit.ts`) takes the advertised `OpenAIFunctionToolDef[]` itself, not a count: VS Code's host tool shape is structurally incompatible, so re-feeding `options.tools` (or any hand-computed number) is a compile error. One deliberate edge: a host list of **any** size whose tools are all unusable now proceeds as a tool-less request (each skip individually logged) instead of throwing the old — and factually wrong — "more than 128 tools" error; this matches what already happened for the same input at ≤128 tools.
+
+### Changed
+
+- **Tool payload assembly extracted to the vscode-free `src/tool_payload.ts`** (`buildToolPayload`: schema sanitization, wire-alias skip logic, tool_choice resolution — moved verbatim from `utils.ts`), leaving `convertTools` as a thin enum→boolean adapter. Third instance of the `tool_names.ts` / `tool_choice.ts` extraction pattern; done so the unit harness can execute the real skip-then-count path instead of asserting about it textually.
+
+### Added
+
+- **`test/unit_tool_limit.mjs`** — pins the cap constant, the guard boundary (128 passes, 129 throws), and the real regression scenario end to end: 130 host tools with 5 unusable names advertise 125 defs and pass, 129 usable defs throw, all-unusable lists advertise nothing, and every skip logs exactly one diagnostic line. A deliberately minimal best-effort text pin over comment-stripped `out/provider.js` guards the two properties the type system can't: the guard call exists in provider.ts, and no inline host-list count check has crept back.
+
 ## [0.3.9] - 2026-08-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
 		"prepare-icon": "node scripts/prepare-icon.mjs",
 		"pretest": "npm run compile",
 		"test": "npm run test:unit",
-		"test:unit": "node test/unit_cache_breakdown.mjs && node test/unit_tool_name_validation.mjs && node test/unit_tool_wire_name.mjs && node test/unit_context_usage.mjs && node test/unit_tool_choice.mjs && node test/unit_request_kind.mjs && node test/unit_reasoning_cache.mjs"
+		"test:unit": "node test/unit_cache_breakdown.mjs && node test/unit_tool_name_validation.mjs && node test/unit_tool_wire_name.mjs && node test/unit_tool_limit.mjs && node test/unit_context_usage.mjs && node test/unit_tool_choice.mjs && node test/unit_request_kind.mjs && node test/unit_reasoning_cache.mjs"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.13.0",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -13,6 +13,7 @@ import type { DeepSeekModelVariant, OpenAIChatMessage } from "./types";
 
 import { convertTools, convertMessages, tryParseJSONObject, validateRequest } from "./utils";
 import { toWireName, buildWireNameMap } from "./tool_names";
+import { assertAdvertisedToolLimit } from "./tool_limit";
 import { ReasoningCache, fingerprintAssistantTurn, type CachedTurn, type ReasoningCacheStats } from "./reasoning_cache";
 import { shouldWarnCacheBreakdown } from "./cache_breakdown";
 import { ContextUsageService } from "./context_usage_service";
@@ -1301,9 +1302,13 @@ export class DeepSeekV4ChatModelProvider implements LanguageModelChatProvider {
             // advertise-side skip in convertTools).
             ctx.wireNameToHost = buildWireNameMap((options.tools ?? []).map((t) => t?.name));
 
-        if (options.tools && options.tools.length > 128) {
-            throw new Error("Cannot have more than 128 tools per request.");
-        }
+            // The cap counts the ADVERTISED set, not options.tools — since
+            // the issue #20 wire-aliasing fix, tool assembly may skip
+            // unusable/colliding tools, so the host list can be over 128
+            // while the set actually broadcast to the API is legal. The
+            // guard's parameter type makes feeding the host list a compile
+            // error; see tool_limit.ts.
+            assertAdvertisedToolLimit(toolConfig.tools);
 
             const messageChars = this.countMessageChars(messages);
             const toolChars = this.countToolChars(toolConfig.tools);

--- a/src/tool_limit.ts
+++ b/src/tool_limit.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure guard for DeepSeek's 128-tools-per-request cap. Extracted from
+ * provider.ts so the boundary is vscode-free and unit-testable without a
+ * vscode mock (same pattern as tool_choice.ts).
+ *
+ * The cap applies to the ADVERTISED (wire) tool set — what buildToolPayload
+ * actually broadcasts to the API — not the raw host list. Since the issue #20
+ * wire-aliasing fix, assembly may skip unusable or colliding tools, so a
+ * host list slightly over 128 can still yield a legal request. Counting the
+ * host list would reject that request for a violation that never reaches the
+ * wire.
+ *
+ * The parameter is the advertised def array itself, not a count: VS Code's
+ * host tool shape ({name, description, inputSchema}) is structurally
+ * incompatible with OpenAIFunctionToolDef, so feeding `options.tools` — or
+ * any hand-computed number — is a COMPILE error, and the original bug can't
+ * be reintroduced through this call. The type-only import keeps the compiled
+ * module dependency-free for the Node unit harness.
+ */
+
+import type { OpenAIFunctionToolDef } from "./types";
+
+export const MAX_TOOLS_PER_REQUEST = 128;
+
+/**
+ * Throw when the advertised tool set exceeds the API cap.
+ * @param advertised The tool defs actually sent to the API; undefined when
+ *   the request advertises no tools (always legal).
+ */
+export function assertAdvertisedToolLimit(advertised: readonly OpenAIFunctionToolDef[] | undefined): void {
+	if ((advertised?.length ?? 0) > MAX_TOOLS_PER_REQUEST) {
+		throw new Error(`Cannot have more than ${MAX_TOOLS_PER_REQUEST} tools per request.`);
+	}
+}

--- a/src/tool_payload.ts
+++ b/src/tool_payload.ts
@@ -1,0 +1,221 @@
+/**
+ * Pure (vscode-free) assembly of the OpenAI tool payload from host tool
+ * descriptors: schema sanitization, wire-name aliasing with first-wins
+ * collision/unusable skips (issue #20), and tool_choice resolution.
+ *
+ * Extracted from `convertTools` in utils.ts — which remains as a thin vscode
+ * adapter (enum → boolean) — so the REAL skip-then-count path is importable
+ * by the Node unit harness (test/unit_tool_limit.mjs) without a vscode mock.
+ * Third instance of the repo's vscode-free extraction pattern
+ * (tool_names.ts, tool_choice.ts).
+ */
+
+import type { OpenAIFunctionToolDef } from "./types";
+import { toWireName, buildWireNameMap } from "./tool_names";
+import { resolveToolChoice, type ToolChoice } from "./tool_choice";
+
+/**
+ * Structural view of a host tool entry (VS Code's `LanguageModelChatTool`),
+ * kept loose enough for the defensive guards below to stay meaningful.
+ */
+export interface HostToolDescriptor {
+	readonly name: string;
+	readonly description?: string;
+	readonly inputSchema?: object;
+}
+
+// Tool calling sanitization helpers
+
+function isIntegerLikePropertyName(propertyName: string | undefined): boolean {
+    if (!propertyName){
+		return false;
+	}
+    const lowered = propertyName.toLowerCase();
+    const integerMarkers = [
+        "id",
+        "limit",
+        "count",
+        "index",
+        "size",
+        "offset",
+        "length",
+        "results_limit",
+        "maxresults",
+        "debugsessionid",
+        "cellid",
+    ];
+    return integerMarkers.some((m) => lowered.includes(m)) || lowered.endsWith("_id");
+}
+
+function pruneUnknownSchemaKeywords(schema: unknown): Record<string, unknown> {
+    if (!schema || typeof schema !== "object" || Array.isArray(schema)){
+		return {};
+	}
+    const allow = new Set([
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+        "description",
+        "enum",
+        "default",
+        "items",
+        "minLength",
+        "maxLength",
+        "minimum",
+        "maximum",
+        "pattern",
+        "format",
+    ]);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
+        if (allow.has(k)){
+			out[k] = v as unknown;
+		}
+    }
+    return out;
+}
+
+function sanitizeSchema(input: unknown, propName?: string): Record<string, unknown> {
+    if (!input || typeof input !== "object" || Array.isArray(input)) {
+        return { type: "object", properties: {} } as Record<string, unknown>;
+    }
+
+    let schema = input as Record<string, unknown>;
+
+    for (const composite of ["anyOf", "oneOf", "allOf"]) {
+        const branch = (schema as Record<string, unknown>)[composite] as unknown;
+        if (Array.isArray(branch) && branch.length > 0) {
+            let preferred: Record<string, unknown> | undefined;
+            for (const b of branch) {
+                if (b && typeof b === "object" && (b as Record<string, unknown>).type === "string") {
+                    preferred = b as Record<string, unknown>;
+                    break;
+                }
+            }
+            schema = { ...(preferred ?? (branch[0] as Record<string, unknown>)) };
+            break;
+        }
+    }
+
+    schema = pruneUnknownSchemaKeywords(schema);
+
+    let t = schema.type as string | undefined;
+    if (t == null) {
+        t = "object";
+        schema.type = t;
+    }
+
+    if (t === "number" && propName && isIntegerLikePropertyName(propName)) {
+        schema.type = "integer";
+        t = "integer";
+    }
+
+    if (t === "object") {
+        const props = (schema.properties as Record<string, unknown> | undefined) ?? {};
+        const newProps: Record<string, unknown> = {};
+        if (props && typeof props === "object") {
+            for (const [k, v] of Object.entries(props)) {
+                newProps[k] = sanitizeSchema(v, k);
+            }
+        }
+        schema.properties = newProps;
+
+        const req = schema.required as unknown;
+        if (Array.isArray(req)) {
+            schema.required = req.filter((r) => typeof r === "string");
+        } else if (req !== undefined) {
+            schema.required = [];
+        }
+
+        const ap = schema.additionalProperties as unknown;
+        if (ap !== undefined && typeof ap !== "boolean") {
+            delete schema.additionalProperties;
+        }
+    } else if (t === "array") {
+        const items = schema.items as unknown;
+        if (Array.isArray(items) && items.length > 0) {
+            schema.items = sanitizeSchema(items[0]);
+        } else if (items && typeof items === "object") {
+            schema.items = sanitizeSchema(items);
+        } else {
+            schema.items = { type: "string" } as Record<string, unknown>;
+        }
+    }
+
+    return schema;
+}
+
+/**
+ * Build the OpenAI function tool defs and tool_choice for one request.
+ * @param tools Host tool descriptors (VS Code's `options.tools`).
+ * @param requiredMode True when the host demands a tool call (VS Code's
+ *   `LanguageModelChatToolMode.Required`).
+ */
+export function buildToolPayload(
+	tools: ReadonlyArray<HostToolDescriptor | null | undefined>,
+	requiredMode: boolean,
+): {
+	tools?: OpenAIFunctionToolDef[];
+	tool_choice?: ToolChoice;
+} {
+	if (!tools || tools.length === 0) {
+		return {};
+	}
+
+	// Every name is deterministically aliased onto DeepSeek's spec
+	// (^[A-Za-z0-9_-]{1,64}$) by toWireName — spec-legal names pass through
+	// untouched. The stream layer reverse-maps the model's echoed alias back
+	// to the host name before reporting (provider.ts), so aliasing is
+	// invisible to VS Code's tool registry. Earlier revisions hard-threw on
+	// the first illegal name instead, which turned one over-long MCP tool
+	// name into a total chat outage (issue #20).
+	const wireToHost = buildWireNameMap(tools.map((t) => t?.name));
+
+	const toolDefs: OpenAIFunctionToolDef[] = [];
+	for (const t of tools) {
+		if (!t || typeof t !== "object") {
+			continue;
+		}
+		const wire = typeof t.name === "string" ? toWireName(t.name) : "";
+		// The typeof guard must be explicit: for `t.name === undefined`,
+		// `wireToHost.get("")` is ALSO undefined, so the membership check
+		// alone would pass (`undefined !== undefined` → false) and advertise
+		// an empty function name — a guaranteed API 400 that kills the whole
+		// request, the exact failure class this aliasing layer exists to
+		// eliminate.
+		if (typeof t.name !== "string" || wireToHost.get(wire) !== t.name) {
+			// Unusable name (empty / non-string) or wire-name collision with
+			// an earlier tool — advertising it would let the model call a
+			// name that dispatches to the wrong tool. Skip just this tool;
+			// the rest of the request proceeds.
+			console.error("[DeepSeek V4] Skipping tool with unusable or colliding name", {
+				name: t.name,
+				wire,
+				collidesWith: wireToHost.get(wire),
+			});
+			continue;
+		}
+		const description = typeof t.description === "string" ? t.description : "";
+		const params = sanitizeSchema(t.inputSchema ?? { type: "object", properties: {} });
+		toolDefs.push({
+			type: "function" as const,
+			function: {
+				name: wire,
+				description,
+				parameters: params,
+			},
+		} satisfies OpenAIFunctionToolDef);
+	}
+
+	if (toolDefs.length === 0) {
+		return {};
+	}
+
+	// Resolution lives in `tool_choice.ts` (vscode-free, unit-tested).
+	// Count and name refer to the ADVERTISED (wire) tool set — a forced
+	// named-function tool_choice must match a name the API was given.
+	const tool_choice = resolveToolChoice(requiredMode, toolDefs.length, toolDefs[0]?.function.name);
+
+	return { tools: toolDefs, tool_choice };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,133 +1,13 @@
 import * as vscode from "vscode";
 import type { OpenAIChatMessage, OpenAIChatRole, OpenAIFunctionToolDef, OpenAIToolCall } from "./types";
-import { toWireName, buildWireNameMap } from "./tool_names";
-import { resolveToolChoice, type ToolChoice } from "./tool_choice";
+import { toWireName } from "./tool_names";
+import type { ToolChoice } from "./tool_choice";
+import { buildToolPayload } from "./tool_payload";
 
-// Tool calling sanitization helpers
-
-function isIntegerLikePropertyName(propertyName: string | undefined): boolean {
-    if (!propertyName){
-		return false;
-	}
-    const lowered = propertyName.toLowerCase();
-    const integerMarkers = [
-        "id",
-        "limit",
-        "count",
-        "index",
-        "size",
-        "offset",
-        "length",
-        "results_limit",
-        "maxresults",
-        "debugsessionid",
-        "cellid",
-    ];
-    return integerMarkers.some((m) => lowered.includes(m)) || lowered.endsWith("_id");
-}
-
-// Tool-name validation and wire-aliasing live in `./tool_names.ts`
-// (pure, vscode-free) so unit tests can import them via Node ESM without
-// a VS Code mock. Re-imported above for in-file usage.
-
-function pruneUnknownSchemaKeywords(schema: unknown): Record<string, unknown> {
-    if (!schema || typeof schema !== "object" || Array.isArray(schema)){
-		return {};
-	}
-    const allow = new Set([
-        "type",
-        "properties",
-        "required",
-        "additionalProperties",
-        "description",
-        "enum",
-        "default",
-        "items",
-        "minLength",
-        "maxLength",
-        "minimum",
-        "maximum",
-        "pattern",
-        "format",
-    ]);
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
-        if (allow.has(k)){
-			out[k] = v as unknown;
-		}
-    }
-    return out;
-}
-
-function sanitizeSchema(input: unknown, propName?: string): Record<string, unknown> {
-    if (!input || typeof input !== "object" || Array.isArray(input)) {
-        return { type: "object", properties: {} } as Record<string, unknown>;
-    }
-
-    let schema = input as Record<string, unknown>;
-
-    for (const composite of ["anyOf", "oneOf", "allOf"]) {
-        const branch = (schema as Record<string, unknown>)[composite] as unknown;
-        if (Array.isArray(branch) && branch.length > 0) {
-            let preferred: Record<string, unknown> | undefined;
-            for (const b of branch) {
-                if (b && typeof b === "object" && (b as Record<string, unknown>).type === "string") {
-                    preferred = b as Record<string, unknown>;
-                    break;
-                }
-            }
-            schema = { ...(preferred ?? (branch[0] as Record<string, unknown>)) };
-            break;
-        }
-    }
-
-    schema = pruneUnknownSchemaKeywords(schema);
-
-    let t = schema.type as string | undefined;
-    if (t == null) {
-        t = "object";
-        schema.type = t;
-    }
-
-    if (t === "number" && propName && isIntegerLikePropertyName(propName)) {
-        schema.type = "integer";
-        t = "integer";
-    }
-
-    if (t === "object") {
-        const props = (schema.properties as Record<string, unknown> | undefined) ?? {};
-        const newProps: Record<string, unknown> = {};
-        if (props && typeof props === "object") {
-            for (const [k, v] of Object.entries(props)) {
-                newProps[k] = sanitizeSchema(v, k);
-            }
-        }
-        schema.properties = newProps;
-
-        const req = schema.required as unknown;
-        if (Array.isArray(req)) {
-            schema.required = req.filter((r) => typeof r === "string");
-        } else if (req !== undefined) {
-            schema.required = [];
-        }
-
-        const ap = schema.additionalProperties as unknown;
-        if (ap !== undefined && typeof ap !== "boolean") {
-            delete schema.additionalProperties;
-        }
-    } else if (t === "array") {
-        const items = schema.items as unknown;
-        if (Array.isArray(items) && items.length > 0) {
-            schema.items = sanitizeSchema(items[0]);
-        } else if (items && typeof items === "object") {
-            schema.items = sanitizeSchema(items);
-        } else {
-            schema.items = { type: "string" } as Record<string, unknown>;
-        }
-    }
-
-    return schema;
-}
+// Tool-name validation/wire-aliasing live in `./tool_names.ts` and the tool
+// payload assembly (schema sanitization, skip logic, tool_choice) in
+// `./tool_payload.ts` — both pure and vscode-free so unit tests can import
+// them via Node ESM without a VS Code mock.
 
 /**
  * Convert VS Code chat request messages into OpenAI-compatible message objects.
@@ -185,76 +65,15 @@ export function convertMessages(messages: readonly vscode.LanguageModelChatReque
 
 /**
  * Convert VS Code tool definitions to OpenAI function tool definitions.
+ * Thin vscode adapter: the actual assembly (aliasing, skips, sanitization,
+ * tool_choice) is the pure `buildToolPayload` in `tool_payload.ts`.
  * @param options Request options containing tools and toolMode.
  */
 export function convertTools(options: vscode.ProvideLanguageModelChatResponseOptions): {
 	tools?: OpenAIFunctionToolDef[];
 	tool_choice?: ToolChoice;
 } {
-	const tools = options.tools ?? [];
-	if (!tools || tools.length === 0) {
-		return {};
-	}
-
-	// Every name is deterministically aliased onto DeepSeek's spec
-	// (^[A-Za-z0-9_-]{1,64}$) by toWireName — spec-legal names pass through
-	// untouched. The stream layer reverse-maps the model's echoed alias back
-	// to the host name before reporting (provider.ts), so aliasing is
-	// invisible to VS Code's tool registry. Earlier revisions hard-threw on
-	// the first illegal name instead, which turned one over-long MCP tool
-	// name into a total chat outage (issue #20).
-	const wireToHost = buildWireNameMap(tools.map((t) => t?.name));
-
-	const toolDefs: OpenAIFunctionToolDef[] = [];
-	for (const t of tools) {
-		if (!t || typeof t !== "object") {
-			continue;
-		}
-		const wire = typeof t.name === "string" ? toWireName(t.name) : "";
-		// The typeof guard must be explicit: for `t.name === undefined`,
-		// `wireToHost.get("")` is ALSO undefined, so the membership check
-		// alone would pass (`undefined !== undefined` → false) and advertise
-		// an empty function name — a guaranteed API 400 that kills the whole
-		// request, the exact failure class this aliasing layer exists to
-		// eliminate.
-		if (typeof t.name !== "string" || wireToHost.get(wire) !== t.name) {
-			// Unusable name (empty / non-string) or wire-name collision with
-			// an earlier tool — advertising it would let the model call a
-			// name that dispatches to the wrong tool. Skip just this tool;
-			// the rest of the request proceeds.
-			console.error("[DeepSeek V4] Skipping tool with unusable or colliding name", {
-				name: t.name,
-				wire,
-				collidesWith: wireToHost.get(wire),
-			});
-			continue;
-		}
-		const description = typeof t.description === "string" ? t.description : "";
-		const params = sanitizeSchema(t.inputSchema ?? { type: "object", properties: {} });
-		toolDefs.push({
-			type: "function" as const,
-			function: {
-				name: wire,
-				description,
-				parameters: params,
-			},
-		} satisfies OpenAIFunctionToolDef);
-	}
-
-	if (toolDefs.length === 0) {
-		return {};
-	}
-
-	// Resolution lives in `tool_choice.ts` (vscode-free, unit-tested).
-	// Count and name refer to the ADVERTISED (wire) tool set — a forced
-	// named-function tool_choice must match a name the API was given.
-	const tool_choice = resolveToolChoice(
-		options.toolMode === vscode.LanguageModelChatToolMode.Required,
-		toolDefs.length,
-		toolDefs[0]?.function.name,
-	);
-
-	return { tools: toolDefs, tool_choice };
+	return buildToolPayload(options.tools ?? [], options.toolMode === vscode.LanguageModelChatToolMode.Required);
 }
 
 /**

--- a/test/unit_tool_limit.mjs
+++ b/test/unit_tool_limit.mjs
@@ -1,0 +1,228 @@
+// Tests for DeepSeek's 128-tools-per-request cap: the pure guard
+// `assertAdvertisedToolLimit`, the REAL skip-then-count path through
+// `buildToolPayload`, and a best-effort text pin on the provider call site.
+//
+// The cap counts the ADVERTISED (wire) tool set — what is actually broadcast
+// to the API — not the raw host list. Since the issue #20 wire-aliasing fix,
+// tool assembly may skip unusable or colliding tools, so the host list can
+// exceed 128 while the broadcast set is legal. Counting the host list (the
+// pre-fix behavior in provider.ts) killed such requests for a violation that
+// never reached the wire.
+//
+// Three layers of protection, strongest first:
+//   1. TYPES — `assertAdvertisedToolLimit` takes the advertised
+//      `OpenAIFunctionToolDef[]`, which is structurally incompatible with
+//      VS Code's host tool list AND with a bare number, so feeding
+//      `options.tools` (or any hand-computed count) is a COMPILE error.
+//      Nothing here can test that; tsc enforces it on every build.
+//   2. BEHAVIOR — section 3 runs the real headline scenario through
+//      `buildToolPayload` (vscode-free): a 130-tool host list with 5
+//      unusable names advertises 125 defs and passes the guard; 129 usable
+//      names throw.
+//   3. TEXT PIN (best-effort) — section 4 scans comment-stripped compiled
+//      `out/provider.js` for "guard call present" and "no inline host-list
+//      count check". Types can't force a call to EXIST, so this is
+//      defense-in-depth against deleting the call or re-adding a host-list
+//      pre-check. It is deliberately minimal and NOT a guarantee: a
+//      determined-enough respelling can evade a text scan.
+//
+//     npm test
+//
+// Exits 0 on all-pass, 1 on any failure.
+
+import process from "node:process";
+import { readFileSync } from "node:fs";
+import { MAX_TOOLS_PER_REQUEST, assertAdvertisedToolLimit } from "../out/tool_limit.js";
+import { buildToolPayload } from "../out/tool_payload.js";
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function check(label, got, expected) {
+	const ok = Object.is(got, expected);
+	if (ok) {
+		passed++;
+		console.log(`  ✓ ${label}`);
+	} else {
+		failed++;
+		failures.push(`  ✗ ${label}\n      expected=${JSON.stringify(expected)} got=${JSON.stringify(got)}`);
+	}
+}
+
+function throwsWith(fn) {
+	try {
+		fn();
+		return { threw: false, message: undefined };
+	} catch (e) {
+		return { threw: true, message: e instanceof Error ? e.message : String(e) };
+	}
+}
+
+/** n minimal advertised tool defs, the shape the guard is typed against. */
+function mkAdvertised(n) {
+	return Array.from({ length: n }, (_, i) => ({
+		type: "function",
+		function: { name: `tool_${i}`, description: "", parameters: { type: "object", properties: {} } },
+	}));
+}
+
+/** n host tool descriptors with usable names. */
+function mkHostTools(n, prefix = "host_tool") {
+	return Array.from({ length: n }, (_, i) => ({
+		name: `${prefix}_${i}`,
+		description: "",
+		inputSchema: { type: "object", properties: {} },
+	}));
+}
+
+/**
+ * Run fn with console.error captured: buildToolPayload logs one line per
+ * skipped tool, which would otherwise drown the test output. Returns the
+ * result plus the number of skip logs, so the diagnostic behavior is pinned
+ * instead of merely silenced.
+ */
+function withCapturedSkipLogs(fn) {
+	const original = console.error;
+	let skipLogs = 0;
+	console.error = () => {
+		skipLogs++;
+	};
+	try {
+		return { result: fn(), skipLogs };
+	} finally {
+		console.error = original;
+	}
+}
+
+// === 1. The cap itself is pinned ===
+// Changing it silently would desynchronize the guard from DeepSeek's API
+// contract — must be a deliberate decision, not drift.
+check("MAX_TOOLS_PER_REQUEST is 128", MAX_TOOLS_PER_REQUEST, 128);
+
+// === 2. Guard boundary over advertised tool-def arrays ===
+check("undefined (no tools advertised) passes", throwsWith(() => assertAdvertisedToolLimit(undefined)).threw, false);
+check("empty array passes", throwsWith(() => assertAdvertisedToolLimit([])).threw, false);
+check("1 advertised tool passes", throwsWith(() => assertAdvertisedToolLimit(mkAdvertised(1))).threw, false);
+check(
+	"exactly 128 advertised tools passes (cap is inclusive)",
+	throwsWith(() => assertAdvertisedToolLimit(mkAdvertised(128))).threw,
+	false,
+);
+const over = throwsWith(() => assertAdvertisedToolLimit(mkAdvertised(129)));
+check("129 advertised tools throws", over.threw, true);
+check("error message names the 128 cap", /128 tools/.test(over.message ?? ""), true);
+check("far over the cap throws too", throwsWith(() => assertAdvertisedToolLimit(mkAdvertised(300))).threw, true);
+
+// === 3. The real headline scenario, executed end to end ===
+// Host list OVER the cap whose skips bring the advertised set back under it.
+// 5 of 130 names are unusable (empty / non-string — the issue #20 skip
+// class), so exactly 125 defs are advertised: a legal request the old
+// `options.tools.length > 128` check killed.
+const hostOverCap = [...mkHostTools(125), ...Array.from({ length: 5 }, () => ({ name: "", description: "" }))];
+check("scenario premise: host list exceeds the cap", hostOverCap.length > MAX_TOOLS_PER_REQUEST, true);
+const overCapRun = withCapturedSkipLogs(() => buildToolPayload(hostOverCap, false));
+const payload = overCapRun.result;
+check("5 unusable names are skipped → 125 advertised", payload.tools?.length, 125);
+check("each skipped tool logged one diagnostic line", overCapRun.skipLogs, 5);
+check(
+	"over-cap host list with legal advertised set passes the guard",
+	throwsWith(() => assertAdvertisedToolLimit(payload.tools)).threw,
+	false,
+);
+// Counter-case: when the ADVERTISED set itself is over the cap, the guard
+// still fires — skips don't grant amnesty to a genuinely oversized request.
+const genuinelyOver = withCapturedSkipLogs(() =>
+	buildToolPayload([...mkHostTools(129), { name: "", description: "" }], false),
+).result;
+check("129 usable of 130 → 129 advertised", genuinelyOver.tools?.length, 129);
+check(
+	"over-cap ADVERTISED set still throws",
+	throwsWith(() => assertAdvertisedToolLimit(genuinelyOver.tools)).threw,
+	true,
+);
+// The all-unusable degenerate: buildToolPayload returns {} (no tools key),
+// and `undefined` passes the guard — a tool-less request is legal however
+// large the host list was. Deliberate; see CHANGELOG.
+const allUnusableRun = withCapturedSkipLogs(() => buildToolPayload(Array.from({ length: 130 }, () => ({ name: "" })), false));
+check("all-unusable host list advertises nothing", allUnusableRun.result.tools, undefined);
+check("all 130 unusable tools logged diagnostics", allUnusableRun.skipLogs, 130);
+check(
+	"tool-less payload passes the guard regardless of host size",
+	throwsWith(() => assertAdvertisedToolLimit(allUnusableRun.result.tools)).threw,
+	false,
+);
+
+// === 4. Best-effort text pin on the compiled provider call site ===
+// Types can't force the guard call to EXIST in provider.ts, and provider.ts
+// can't be imported here (it needs the runtime `vscode` module). So scan the
+// compiled text for the two properties types can't give us: the guard is
+// called, and no inline host-list count check has crept back. Comments are
+// stripped first so prose mentioning either pattern can neither satisfy nor
+// trip the pin (tsc preserves comments; a commented-out call must not count).
+// Best-effort by design — the load-bearing protections are layers 1 and 2.
+function stripComments(src) {
+	let out = "";
+	let mode = "code"; // code | line | block | sq | dq | tpl
+	for (let i = 0; i < src.length; i++) {
+		const c = src[i];
+		const n = src[i + 1];
+		if (mode === "code") {
+			if (c === "/" && n === "/") {
+				mode = "line";
+				i++;
+			} else if (c === "/" && n === "*") {
+				mode = "block";
+				i++;
+			} else {
+				if (c === "'") mode = "sq";
+				else if (c === '"') mode = "dq";
+				else if (c === "`") mode = "tpl";
+				out += c;
+			}
+		} else if (mode === "line") {
+			if (c === "\n") {
+				mode = "code";
+				out += c;
+			}
+		} else if (mode === "block") {
+			if (c === "*" && n === "/") {
+				mode = "code";
+				i++;
+			}
+		} else {
+			out += c;
+			if (c === "\\") {
+				out += n ?? "";
+				i++;
+			} else if ((mode === "sq" && c === "'") || (mode === "dq" && c === '"') || (mode === "tpl" && c === "`")) {
+				mode = "code";
+			}
+		}
+	}
+	return out;
+}
+
+const providerJs = stripComments(readFileSync(new URL("../out/provider.js", import.meta.url), "utf8"));
+check("provider calls the guard (live code, comments stripped)", providerJs.includes("assertAdvertisedToolLimit"), true);
+// Catches the natural respellings of the old bug in one shape family:
+// `options.tools….length … >` — covers `options.tools.length > 128`,
+// `options.tools?.length ?? 0) > MAX_TOOLS_PER_REQUEST`,
+// `(options.tools ?? []).length >= 129`, etc.
+check(
+	"no inline host-list count check in live code",
+	/options\.tools[^;\n]{0,40}\.length[^;\n]{0,20}>/.test(providerJs),
+	false,
+);
+
+console.log("");
+console.log(`=== Results: ${passed} passed, ${failed} failed ===`);
+if (failed > 0) {
+	console.log("");
+	console.log("Failures:");
+	for (const f of failures) {
+		console.log(f);
+	}
+	process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
## Summary

Follow-up to the #20 wire-aliasing fix: the 128-tools-per-request guard in `provideLanguageModelChatResponse` still counted `options.tools` (the raw host list), but tool assembly may now skip unusable/colliding tools — so a host list slightly over 128 whose broadcast set is legal was rejected for a violation that never reached the wire.

- **Typed guard** — `assertAdvertisedToolLimit` (`src/tool_limit.ts`) takes the advertised `OpenAIFunctionToolDef[]` itself, not a count. VS Code's host tool shape is structurally incompatible, so re-feeding `options.tools` (or any hand-computed number) fails to compile (verified: tsc rejects both shapes with TS2345).
- **vscode-free assembly** — the sanitize chain + skip loop + tool_choice resolution move verbatim from `utils.ts` to the pure `src/tool_payload.ts` (third `tool_names.ts`/`tool_choice.ts`-style extraction); `convertTools` stays as a thin enum→boolean adapter.
- **Real-path test** — `test/unit_tool_limit.mjs` (19 assertions) executes the headline scenario end to end: 130 host tools with 5 unusable names → 125 advertised → guard passes; 129 usable → throws; all-unusable → tool-less request, one diagnostic log per skip. A minimal best-effort text pin over comment-stripped `out/provider.js` covers what types can't: the guard call exists and no inline host-list count check has crept back (verified red on a simulated revert).
- **Deliberate edge documented** — an all-unusable host list of any size now proceeds tool-less instead of throwing the misleading "more than 128 tools" error, consistent with the same input at ≤128 tools.

## Test plan

- [x] `npm test` — 8 suites, 189 assertions, all green
- [x] `npm run lint` — clean
- [x] Compile-block experiment: feeding `options.tools` / a bare number → TS2345 in both cases
- [x] Revert experiment: commented-out guard + respelled host check → both pin assertions fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)